### PR TITLE
bug fix: Preserve parent actions if child states

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ function getActions(states) {
       const state = states[key]
       const actions = Object.keys(state.on || {})
 
-      return state.states ? getActions(state.states) : actions
+      return state.states ? getActions(state.states).concat(actions) : actions
     })
     .reduce((a, b) => a.concat(b), [])
     .filter((key, pos, arr) => arr.indexOf(key) === pos)


### PR DESCRIPTION
The parent actions are not being preserved if there are substates. Need this if the parent is handling the action when in the child state.